### PR TITLE
#8 Proper visualization of operations (hotfix)

### DIFF
--- a/app/sections/generic-search/generic-search.service.js
+++ b/app/sections/generic-search/generic-search.service.js
@@ -72,8 +72,18 @@
 
                     // the code below generates the response in specific format and
                     // adds groups' titles to split accounts / transactions / blocks etc. in the dropdown list
+                    
+                    const mapOperationsProperType = (item) => {
+                        return item.identifier.indexOf('1.11') === 0 ? {
+                            ...item,
+                            type: SEARCH_TYPES.OPERATION,
+                        } : {
+                            ...item,
+                        }
+                    }
+                    
                     try {
-                        items = response.data.found;
+                        items = (Array.isArray(response.data.found) ? response.data.found : []).map(mapOperationsProperType);
 
                         for(let i = 0; i < items.length; i++) {
                             if(i === 0) {


### PR DESCRIPTION
**Issue**: #8 

**Description** 

Actually, it's more of a `hotfix` instead of a `feature`. The search doesn't display operations properly because the backend response identifies the operation as an object. If to replace the `type` of the response item with `operation` - it will display it properly. So my advice is **to apply a fix on the backend side instead of merging that PR**. 

Currently, my hotfix just maps response items and replaces `object`->`operation` for the `identifier` beginning of `1.11` 
```
{
  "found": [
    {
      "type": "object", <-- it should be an operation instead of object
      "identifier": "1.11.1230261974"
    }
  ],
  "tags": {
    "account": "1.11.1230261974",
    "asset": "1.11.1230261974",
    "block": "1.11.1230261974",
    "object": "1.11.1230261974"
  },
  "expression": "1.11.1230261974"
}
```

<img width="325" alt="Screenshot 2022-10-11 at 14 38 27" src="https://user-images.githubusercontent.com/7770343/195079967-923a457e-277f-49fa-8d95-f8cba7c39afb.png">
