### PR TITLE
#15 Fix operations pagination

### DIFF
--- a/app/core/service.network.js
+++ b/app/core/service.network.js
@@ -63,11 +63,12 @@
 
                 });
             },
-            getLastOperations: function(limit, from, callback) {
+            getLastOperations: function(limit, from, date_to = (new Date().toISOString()), callback) {
                 return $http.get(appConfig.urls.elasticsearch_wrapper() + "/account_history"
                     + "?limit=" + limit
                     + "&offset=" + from
                     + (from < 1000000 ? "&from_date=now-1M" : "&from_date=2015-10-10")
+                    + "&to_date=" + date_to
                 ).then(response => {
                     let last_ops = [];
 

--- a/app/sections/dashboard/dashboard.controller.js
+++ b/app/sections/dashboard/dashboard.controller.js
@@ -45,15 +45,23 @@
                 hidden: ['xs', 'sm', 'md']
             }
         ];
+        
+        $scope.userOpenedFirstPageTime = null;
 
         $scope.select = function(page_operations) {
             const page = page_operations -1;
             const limit = 20;
             const from = page * limit;
+            
+            if(page_operations === 1 || !$scope.userOpenedFirstPageTime) { // if user switches back from page Y (Y>1) to page 1 we need to fetch new transactions and update time range
+                $scope.userOpenedFirstPageTime = new Date();
+            }
+            
+            const date_to = $scope.userOpenedFirstPageTime.toISOString();
 
             $scope.operationsLoading = true;
             $scope.operationsLoadingError = false;
-            networkService.getLastOperations(limit, from, function (returnData) {
+            networkService.getLastOperations(limit, from, date_to, function (returnData) {
                 $scope.operationsLoading = false;
                 $scope.operations = returnData;
                 $scope.currentPage = page_operations;

--- a/app/sections/operations/operations.controller.js
+++ b/app/sections/operations/operations.controller.js
@@ -44,14 +44,22 @@
                         hidden: ['xs', 'sm', 'md']
                     }
                 ];
+                
+                $scope.userOpenedFirstPageTime = null;
 
                 $scope.select = function (page_operations) {
                     const page = page_operations - 1;
                     const limit = 50;
                     const from = page * limit;
+                    
+                    if(page_operations === 1 || !$scope.userOpenedFirstPageTime) { // if user switches back from page Y (Y>1) to page 1 we need to fetch new transactions and update time range
+                        $scope.userOpenedFirstPageTime = new Date();
+                    }
+                    
+                    const date_to = $scope.userOpenedFirstPageTime.toISOString();
 
                     $scope.operationsLoading = true;
-                    networkService.getLastOperations(limit, from, function (returnData) {
+                    networkService.getLastOperations(limit, from, date_to, function (returnData) {
                         $scope.operationsLoading = false;
                         $scope.operations = returnData;
                         $scope.currentPage = page_operations;


### PR DESCRIPTION
**Issue** #15 

**Description**:
Tested and works fine. If user switches back to page #1 (from page X when X>1) it fetches a new list of transactions. If it's not the expected behaviour let me know


Closes #15 